### PR TITLE
accept datetime values with and without timezone info

### DIFF
--- a/app/routers/routes.py
+++ b/app/routers/routes.py
@@ -1,6 +1,7 @@
 # app/routers/routes.py
 from fastapi import APIRouter, Depends, HTTPException
 from datetime import datetime
+from datetime import UTC
 from app.schemas import Route
 from app.models import RouteModel
 from app.database import SessionLocal
@@ -24,7 +25,10 @@ def get_routes():
 def schedule_route(route: Route):
     db = SessionLocal()
     try:
-        now = datetime.now()
+        if route.create_at and route.create_at.tzinfo:
+            now = datetime.now(UTC)
+        else:
+            now = datetime.now()
         logger.info(f"Scheduling route: {route}")
 
         if route_exists(route.destination, route.gateway, route.interface):


### PR DESCRIPTION
This PR adds support for timezone aware values for `delete_at` and `delete_at` and fixes bug: 
```
ERROR - Error scheduling route: can't compare offset-naive and offset-aware datetimes
```

It is done by comparing the input timestamp with the local UTC time.